### PR TITLE
renovate: harden GitOps automation

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,5 +1,8 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  // Repo-local policy only. Org/runtime defaults, manager enablement, and
+  // custom extraction rules live in the in-cluster Renovate ConfigMap.
   extends: [
     "config:recommended",
     "docker:enableMajor",
@@ -8,56 +11,37 @@
     ":dependencyDashboard",
     ":semanticCommits",
   ],
+
   dependencyDashboard: true,
   dependencyDashboardTitle: "Renovate Dashboard 🤖",
-  schedule: ["every weekend"],
+  rebaseWhen: "behind-base-branch",
+  fetchChangeLogs: "pr",
+  separateMajorMinor: true,
+
   ignorePaths: [
     "**/*.sops.*",
     // The app is not referenced from observability/kustomization.yaml.
     "kubernetes/apps/observability/twitch-exporter/**",
   ],
-  flux: {
-    managerFilePatterns: [
-      "/(^|/)kubernetes/.+/(?:helmrelease(?:-[^/]+)?|helmrepository|ks(?:-[^/]+)?|kustomization|receiver|grafana-annotations)\\.ya?ml(?:\\.j2)?$/",
-    ],
-  },
-  helmfile: {
-    managerFilePatterns: [
-      "/(^|/)helmfile\\.ya?ml(?:\\.gotmpl)?(?:\\.j2)?$/",
-      "/(^|/)helmfile\\.d/.+\\.ya?ml(?:\\.gotmpl)?(?:\\.j2)?$/",
-    ],
-  },
-  kubernetes: {
-    managerFilePatterns: ["/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/"],
-  },
-  kustomize: {
-    managerFilePatterns: ["/^kustomization\\.ya?ml(?:\\.j2)?$/"],
-  },
+
   postUpgradeTasks: {
     commands: ["./scripts/update-oci-digests.sh"],
     fileFilters: ["kubernetes/apps/**/ocirepository.yaml"],
     executionMode: "branch",
   },
+
+  prBodyNotes: [
+    "{{#if isMajor}}⚠️ Major update: review upstream migration notes, chart values, and rollout impact before merging.{{/if}}",
+    "{{#if isVulnerabilityAlert}}Security update: prioritize review and verify the vulnerable component is actually deployed.{{/if}}",
+    "{{#if isGroup}}Grouped GitOps PR: confirm the group is operationally coherent before enabling automerge.{{/if}}",
+  ],
+
   packageRules: [
     {
       description: "Keep Renovate's Flux manager away from digest-pinned OCIRepository files. OCIRepository tags are updated by custom.regex and scripts/update-oci-digests.sh refreshes spec.ref.digest from the registry manifest digest.",
       matchManagers: ["flux"],
       pinDigests: false,
-    },
-    {
-      description: "Manage Flux OCIRepository tags without asking Renovate to calculate digest-only OCI Helm chart updates.",
-      matchManagers: ["custom.regex"],
-      matchFileNames: ["kubernetes/apps/**/ocirepository.yaml"],
-      matchDatasources: ["docker"],
-      pinDigests: false,
-    },
-    {
-      description: "Disable digest-only and pin-digest updates for Flux OCIRepository custom regex deps; scripts/update-oci-digests.sh owns spec.ref.digest.",
-      matchManagers: ["custom.regex"],
-      matchFileNames: ["kubernetes/apps/**/ocirepository.yaml"],
-      matchDatasources: ["docker"],
-      matchUpdateTypes: ["pinDigest", "digest"],
-      enabled: false,
+      separateMultipleMajor: true,
     },
     {
       description: "Override Helmfile Dependency Name",
@@ -76,227 +60,74 @@
       minimumGroupSize: 2,
     },
     {
-      description: "Auto-merge GitHub Actions",
+      description: "Auto-merge GitHub Actions only after checks pass",
       matchManagers: ["github-actions"],
       automerge: true,
       automergeType: "branch",
       matchUpdateTypes: ["minor", "patch", "digest"],
-      ignoreTests: true,
     },
     {
-      description: "Auto-merge Mise Tools",
+      description: "Auto-merge Mise tools only after checks pass",
       matchManagers: ["mise"],
       automerge: true,
       automergeType: "branch",
       matchUpdateTypes: ["minor", "patch"],
-      ignoreTests: true,
     },
     {
+      description: "Require dashboard approval and release soak time for major updates",
       matchUpdateTypes: ["major"],
+      dependencyDashboardApproval: true,
+      minimumReleaseAge: "14 days",
+      addLabels: ["type/major"],
       semanticCommitType: "feat",
       commitMessagePrefix: "{{semanticCommitType}}({{semanticCommitScope}})!:",
       commitMessageExtra: "( {{currentVersion}} ➔ {{newVersion}} )",
     },
     {
+      description: "Use feature commits and short soak time for minor updates",
       matchUpdateTypes: ["minor"],
+      minimumReleaseAge: "3 days",
+      addLabels: ["type/minor"],
       semanticCommitType: "feat",
       commitMessageExtra: "( {{currentVersion}} ➔ {{newVersion}} )",
     },
     {
+      description: "Use fix commits for patch updates",
       matchUpdateTypes: ["patch"],
+      minimumReleaseAge: "1 day",
+      addLabels: ["type/patch"],
       semanticCommitType: "fix",
       commitMessageExtra: "( {{currentVersion}} ➔ {{newVersion}} )",
     },
     {
+      description: "Digest-only updates carry digest labels and do not need changelogs",
       matchUpdateTypes: ["digest"],
+      addLabels: ["type/digest"],
       semanticCommitType: "chore",
       commitMessageExtra: "( {{currentDigestShort}} ➔ {{newDigestShort}} )",
+      fetchChangeLogs: "off",
     },
     {
-      matchDatasources: ["docker"],
-      semanticCommitScope: "container",
-      commitMessageTopic: "image {{depName}}",
-    },
-    {
-      matchDatasources: ["helm"],
-      semanticCommitScope: "helm",
-      commitMessageTopic: "chart {{depName}}",
-    },
-    {
-      matchManagers: ["github-actions"],
-      semanticCommitType: "ci",
-      semanticCommitScope: "github-action",
-      commitMessageTopic: "action {{depName}}",
-    },
-    {
-      matchDatasources: ["github-releases"],
-      semanticCommitScope: "github-release",
-      commitMessageTopic: "release {{depName}}",
-    },
-    {
-      matchManagers: ["mise"],
-      semanticCommitScope: "mise",
-      commitMessageTopic: "tool {{depName}}",
-    },
-    {
-      matchUpdateTypes: ["major"],
-      labels: ["type/major"],
-    },
-    {
+      description: "Gate minor updates for cluster-critical namespaces",
+      matchFileNames: [
+        "kubernetes/apps/cert-manager/**",
+        "kubernetes/apps/cnpg-dr/**",
+        "kubernetes/apps/cnpg-system/**",
+        "kubernetes/apps/flux-system/**",
+        "kubernetes/apps/kube-system/**",
+        "kubernetes/apps/longhorn-system/**",
+        "kubernetes/apps/network/**",
+        "kubernetes/apps/renovate/**",
+      ],
       matchUpdateTypes: ["minor"],
-      labels: ["type/minor"],
+      dependencyDashboardApproval: true,
+      minimumReleaseAge: "7 days",
     },
     {
-      matchUpdateTypes: ["patch"],
-      labels: ["type/patch"],
-    },
-    {
-      matchUpdateTypes: ["digest"],
-      labels: ["type/digest"],
-    },
-    {
-      matchDatasources: ["docker"],
-      addLabels: ["renovate/container"],
-    },
-    {
-      matchDatasources: ["helm"],
-      addLabels: ["renovate/helm"],
-    },
-    {
-      matchManagers: ["github-actions"],
-      addLabels: ["renovate/github-action"],
-    },
-    {
-      matchDatasources: ["github-releases"],
-      addLabels: ["renovate/github-release"],
-    },
-    {
-      description: "Group arc-systems updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/arc-systems/**"],
-      groupName: "arc-systems namespace",
-      additionalBranchPrefix: "arc-systems-",
-    },
-    {
-      description: "Group backstage updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/backstage/**"],
-      groupName: "backstage namespace",
-      additionalBranchPrefix: "backstage-",
-    },
-    {
-      description: "Group cert-manager updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/cert-manager/**"],
-      groupName: "cert-manager namespace",
-      additionalBranchPrefix: "cert-manager-",
-    },
-    {
-      description: "Group cnpg-dr updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/cnpg-dr/**"],
-      groupName: "cnpg-dr namespace",
-      additionalBranchPrefix: "cnpg-dr-",
-    },
-    {
-      description: "Group cnpg-system updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/cnpg-system/**"],
-      groupName: "cnpg-system namespace",
-      additionalBranchPrefix: "cnpg-system-",
-    },
-    {
-      description: "Group default updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/default/**"],
-      groupName: "default namespace",
-      additionalBranchPrefix: "default-",
-    },
-    {
-      description: "Group drawio updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/drawio/**"],
-      groupName: "drawio namespace",
-      additionalBranchPrefix: "drawio-",
-    },
-    {
-      description: "Group excalidraw updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/excalidraw/**"],
-      groupName: "excalidraw namespace",
-      additionalBranchPrefix: "excalidraw-",
-    },
-    {
-      description: "Group flux-system updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/flux-system/**"],
-      groupName: "flux-system namespace",
-      additionalBranchPrefix: "flux-system-",
-    },
-    {
-      description: "Group freshrss updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/freshrss/**"],
-      groupName: "freshrss namespace",
-      additionalBranchPrefix: "freshrss-",
-    },
-    {
-      description: "Group invoiceninja updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/invoiceninja/**"],
-      groupName: "invoiceninja namespace",
-      additionalBranchPrefix: "invoiceninja-",
-    },
-    {
-      description: "Group kube-system updates into a dedicated PR — separate major bumps for cluster-critical components",
-      matchFileNames: ["kubernetes/apps/kube-system/**"],
-      groupName: "kube-system namespace",
-      additionalBranchPrefix: "kube-system-",
-      separateMinorPatch: true,
-    },
-    {
-      description: "Group longhorn-system updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/longhorn-system/**"],
-      groupName: "longhorn-system namespace",
-      additionalBranchPrefix: "longhorn-system-",
-    },
-    {
-      description: "Group minecraft updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/minecraft/**"],
-      groupName: "minecraft namespace",
-      additionalBranchPrefix: "minecraft-",
-    },
-    {
-      description: "Group n8n updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/n8n/**"],
-      groupName: "n8n namespace",
-      additionalBranchPrefix: "n8n-",
-    },
-    {
-      description: "Group network updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/network/**"],
-      groupName: "network namespace",
-      additionalBranchPrefix: "network-",
-    },
-    {
-      description: "Group observability updates into a dedicated PR — separate major bumps to avoid multi-major upgrade timeout failures",
-      matchFileNames: ["kubernetes/apps/observability/**"],
-      groupName: "observability namespace",
-      additionalBranchPrefix: "observability-",
-      separateMinorPatch: true,
-    },
-    {
-      description: "Group renovate updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/renovate/**"],
-      groupName: "renovate namespace",
-      additionalBranchPrefix: "renovate-",
-    },
-    {
-      description: "Group searxng updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/searxng/**"],
-      groupName: "searxng namespace",
-      additionalBranchPrefix: "searxng-",
-    },
-    {
-      description: "Group sparkyfitness updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/sparkyfitness/**"],
-      groupName: "sparkyfitness namespace",
-      additionalBranchPrefix: "sparkyfitness-",
-    },
-    {
-      description: "Group zomboid updates into a dedicated PR",
-      matchFileNames: ["kubernetes/apps/zomboid/**"],
-      groupName: "zomboid namespace",
-      additionalBranchPrefix: "zomboid-",
+      description: "Split GitOps app changes by nearest package directory without maintaining one packageRule per namespace",
+      matchFileNames: ["kubernetes/apps/**"],
+      groupName: "kubernetes {{parentDir}}",
+      additionalBranchPrefix: "{{parentDir}}-",
     },
     {
       description: "Group shared app-template updates into a dedicated PR",
@@ -312,52 +143,35 @@
       groupName: "shared busybox",
       additionalBranchPrefix: "shared-busybox-",
     },
-  ],
-  customManagers: [
     {
-      customType: "regex",
-      description: "Process Flux OCIRepository tags; spec.ref.digest is refreshed by scripts/update-oci-digests.sh",
-      managerFilePatterns: [
-        "/(^|/)kubernetes/apps/.+/ocirepository\\.ya?ml(?:\\.j2)?$/",
-      ],
-      matchStrings: [
-        "kind:\\s*OCIRepository[\\s\\S]*?ref:\\s*\\n[\\s\\S]*?tag:\\s*(?<currentValue>\\S+)[\\s\\S]*?url:\\s*oci://(?<depName>\\S+)",
-        "kind:\\s*OCIRepository[\\s\\S]*?url:\\s*oci://(?<depName>\\S+)[\\s\\S]*?ref:\\s*\\n[\\s\\S]*?tag:\\s*(?<currentValue>\\S+)",
-      ],
-      datasourceTemplate: "docker",
+      matchDatasources: ["docker"],
+      semanticCommitScope: "container",
+      commitMessageTopic: "image {{depName}}",
+      addLabels: ["renovate/container"],
     },
     {
-      description: "Process annotated dependencies",
-      customType: "regex",
-      managerFilePatterns: [
-        "/(^|/).+\\.env(?:\\.j2)?$/",
-        "/(^|/).+\\.sh(?:\\.j2)?$/",
-        "/(^|/).+\\.ya?ml(?:\\.j2)?$/",
-      ],
-      matchStrings: [
-        // # renovate: datasource=github-releases depName=k3s-io/k3s
-        // k3s_release_version: &version v1.29.0+k3s1
-        // # renovate: datasource=helm depName=cilium repository=https://helm.cilium.io
-        // version: 1.15.1
-        // # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-        // KUBERNETES_VERSION=v1.31.1
-        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( repository=(?<registryUrl>\\S+))?\\n.+(:\\s|=)(&\\S+\\s)?(?<currentValue>\\S+)",
-        // # renovate: datasource=docker depName=ghcr.io/prometheus-operator/prometheus-operator
-        // https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.80.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
-        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n.+/(?<currentValue>(v|\\d)[^/]+)",
-      ],
-      datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+      matchDatasources: ["helm"],
+      semanticCommitScope: "helm",
+      commitMessageTopic: "chart {{depName}}",
+      addLabels: ["renovate/helm"],
     },
     {
-      customType: "regex",
-      description: "Process OCI dependencies",
-      managerFilePatterns: [
-        "/\\.yaml(?:\\.j2)?$/",
-      ],
-      matchStrings: [
-        "oci://(?<depName>[A-Za-z0-9._/-]+):(?<currentValue>\\S+)",
-      ],
-      datasourceTemplate: "docker",
+      matchManagers: ["github-actions"],
+      semanticCommitType: "ci",
+      semanticCommitScope: "github-action",
+      commitMessageTopic: "action {{depName}}",
+      addLabels: ["renovate/github-action"],
+    },
+    {
+      matchDatasources: ["github-releases"],
+      semanticCommitScope: "github-release",
+      commitMessageTopic: "release {{depName}}",
+      addLabels: ["renovate/github-release"],
+    },
+    {
+      matchManagers: ["mise"],
+      semanticCommitScope: "mise",
+      commitMessageTopic: "tool {{depName}}",
     },
   ],
 }

--- a/docs/techdocs/docs/renovate.md
+++ b/docs/techdocs/docs/renovate.md
@@ -69,15 +69,16 @@ What it does (as configured):
 
 - Discovers repositories matching `webgrip/*`.
 - Runs on cron schedule `0 */2 * * *` (every 2 hours).
-- Runs up to 5 repositories in parallel (`parallelism: 5`).
+- Runs up to 2 repositories in parallel (`parallelism: 2`).
 - Uses `RENOVATE_CONFIG_FILE=/config/renovate.json` mounted from a ConfigMap.
 - Uses webhook authentication from Secret `renovate-webhook-auth`.
+- Runs as a non-root user with `RENOVATE_BASE_DIR=/tmp`.
 
 Operational implication:
 
 - “I checked a Dependency Dashboard checkbox, why no PR?” is usually answered by:
   - waiting for the next scheduled run, and/or
-  - schedule gating in repo config (see next section).
+  - Dependency Dashboard or release-age gating in repo config (see next section).
 
 ## Renovate configuration: layering, precedence, and the two places to edit
 
@@ -101,13 +102,15 @@ The global config is stored as JSON in a ConfigMap and mounted into the Renovate
 
 Important behaviors in the current global config:
 
-- Managers enabled include: `flux`, `kustomize`, `helm-values`, `helmfile`, `github-actions`, plus many language ecosystems.
+- Managers enabled are intentionally scoped to this GitOps estate: `flux`, `kustomize`, `kubernetes`, `helm-values`, `helmfile`, `custom.regex`, `github-actions`, `mise`, `dockerfile`, and `docker-compose`.
 - Dependency Dashboard enabled and auto-closing enabled.
 - Experimental OSV vulnerability alerts are enabled, and the Dependency Dashboard lists unresolved OSV CVEs for direct dependencies.
+- Merge Confidence badges are enabled for ecosystems supported by Renovate/Mend so applicable PRs show age, adoption, passing, and confidence signals.
 - Grouping is defined via `packageRules` (e.g. “GitOps container images”, “Flux controllers & OCI artifacts”, “GitHub Actions”), and Flux updates are intentionally split into patch and minor PRs so patch updates can auto-merge while minor updates stay for manual review.
-- Major updates require Dependency Dashboard approval (`dependencyDashboardApproval: true`).
-- It is resilient to flaky registries: `abortOnExternalHostError: false`.
-- Schedule defaults to `at any time` and no `minimumReleaseAge` delay is configured.
+- Major updates require Dependency Dashboard approval (`dependencyDashboardApproval: true`) and a release-age soak.
+- Schedule defaults to `at any time`; repo-level package rules add release-age delays for risky updates.
+- Changelogs are fetched for PRs by default, except digest-only updates.
+- The global config owns manager enablement, custom extraction rules, post-upgrade command allowlisting, Git author identity, and org-wide safety defaults.
 - `autodiscover: false` is set in Renovate config. Discovery is handled by the RenovateJob/operator layer, and each execution should only handle the intended repository.
 
 Ignore paths are defined globally too (including `bootstrap/**` and `talos/**`).
@@ -119,12 +122,12 @@ The repo config is where “house style” lives.
 Key behaviors in the current repo config:
 
 - Dependency Dashboard enabled and the title is customized.
-- Schedule is restricted: `schedule: ["every weekend"]`.
-- Semantic commit conventions, commit message formatting, and update-type labeling.
-- A GitHub Actions packageRule enables automerge for minor/patch/digest updates.
-- GitOps changes under `kubernetes/apps/*` are regrouped by top-level app directory so each namespace/area gets its own Renovate PR.
+- The repo does **not** define a global schedule; the in-cluster ConfigMap owns schedule policy.
+- Semantic commit conventions, commit message formatting, update-type labeling, and PR body notes.
+- A GitHub Actions packageRule enables automerge for minor/patch/digest updates only after checks pass.
+- GitOps changes under `kubernetes/apps/*` are regrouped by nearest package directory using Renovate templating instead of one rule per namespace.
 - Reused dependencies that span many apps, such as `ghcr.io/bjw-s-labs/helm/app-template`, are carved back out into shared PRs to avoid one dependency generating many near-identical namespace PRs.
-- Two custom regex managers are defined to process `# renovate:` annotations.
+- Cluster-critical namespaces require Dependency Dashboard approval for minor updates and a longer release-age soak before PR creation.
 
 Annotated dependency pins are the mechanism used for values that aren’t otherwise discoverable by a native manager. Example:
 
@@ -142,9 +145,10 @@ Array merge/override behavior can materially change what Renovate scans. If a de
 This repo uses Renovate to keep PR noise manageable:
 
 - Global defaults still provide coarse grouping by manager/datasource.
-- Repo-level packageRules then split `kubernetes/apps/*` updates by top-level app directory, so `observability`, `network`, `sparkyfitness`, and similar areas get separate PRs instead of one repo-wide GitOps batch.
+- Repo-level packageRules then split `kubernetes/apps/*` updates by nearest package directory, so app/component areas get separate PRs instead of one repo-wide GitOps batch.
 - A small set of shared cross-namespace dependencies can override that split later in the rule order and stay repo-wide when that produces cleaner PRs.
-- Major updates are gated by the Dependency Dashboard approval checkbox.
+- Major updates are gated by the Dependency Dashboard approval checkbox and a release-age soak.
+- Minor updates for cluster-critical namespaces are also dashboard-gated.
 
 Automerge behavior is defined in both places:
 
@@ -155,8 +159,8 @@ If a PR isn’t opening when you expect it to, check these in order:
 
 1. Is there actually an update available?
 2. Did the run execute successfully?
-3. Is it blocked by schedule (`every weekend`)?
-4. Is it blocked by Dependency Dashboard approval (major updates)?
+3. Is it blocked by `minimumReleaseAge` / pending release-age checks?
+4. Is it blocked by Dependency Dashboard approval (major updates, or minor updates in cluster-critical namespaces)?
 5. Is it blocked by GitHub permissions/branch protections?
 
 ## GitHub repo conventions used with Renovate
@@ -232,7 +236,7 @@ Renovate itself uses a runtime token secret created/updated in-cluster.
 
 Mechanics (as implemented):
 
-- The CronJob mints a GitHub App installation token.
+- The CronJob mints a GitHub App installation token every 30 minutes.
 - It applies a Secret `renovate-runtime-token` in namespace `renovate` containing `token` and `RENOVATE_TOKEN`.
 
 ## Vulnerability sources
@@ -286,7 +290,7 @@ kubectl -n renovate logs job/<k8s-job-name> --all-containers --tail=200
 
 1. No PRs, but the Dependency Dashboard is updating
 
-   - Often schedule gating (`every weekend`) or major-approval gating.
+   - Often release-age gating or Dependency Dashboard approval gating.
 2. Run fails with registry/auth errors
 
    - GHCR 403 when reading a private package: GitHub App needs **Packages: read** and correct installation scope.

--- a/kubernetes/apps/renovate/renovate-operator/jobs/configmap-gitops.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/configmap-gitops.yaml
@@ -18,7 +18,8 @@ data:
         ":pinDevDependencies",
         ":maintainLockFilesWeekly",
 
-        "abandonments:recommended"
+        "abandonments:recommended",
+        "mergeConfidence:all-badges"
       ],
 
       "platform": "github",
@@ -27,19 +28,17 @@ data:
       "requireConfig": "optional",
 
       "timezone": "Europe/Amsterdam",
+      "gitAuthor": "Renovate Bot <renovate-bot@webgrip.nl>",
 
       "updateNotScheduled": false,
-      "prConcurrentLimit": 4,
+      "prConcurrentLimit": 8,
       "prHourlyLimit": 0,
-
-      "branchConcurrentLimit": 6,
+      "branchConcurrentLimit": 12,
       "commitBodyTable": true,
       "allowedCommands": ["^./scripts/update-oci-digests\\.sh$"],
 
-      "rebaseWhen": "conflicted",
-      "recreateWhen": "auto",
-      "fetchChangeLogs": "off",
-
+      "rebaseWhen": "behind-base-branch",
+      "fetchChangeLogs": "pr",
       "schedule": ["at any time"],
 
       "dependencyDashboard": true,
@@ -64,27 +63,12 @@ data:
       "enabledManagers": [
         "flux",
         "kustomize",
+        "kubernetes",
         "helm-values",
         "helmfile",
         "custom.regex",
-
         "github-actions",
-        "pre-commit",
-
-        "terraform",
-        "terragrunt",
-
-        "npm",
-        "pip_requirements",
-        "poetry",
-        "pipenv",
-        "gomod",
-        "cargo",
-        "maven",
-        "gradle",
-        "composer",
-        "nuget",
-
+        "mise",
         "dockerfile",
         "docker-compose"
       ],
@@ -93,6 +77,21 @@ data:
         "managerFilePatterns": [
           "/(^|/)kubernetes/.+/(?:helmrelease(?:-[^/]+)?|helmrepository|ks(?:-[^/]+)?|kustomization|receiver|grafana-annotations)\\.ya?ml(?:\\.j2)?$/"
         ]
+      },
+
+      "helmfile": {
+        "managerFilePatterns": [
+          "/(^|/)helmfile\\.ya?ml(?:\\.gotmpl)?(?:\\.j2)?$/",
+          "/(^|/)helmfile\\.d/.+\\.ya?ml(?:\\.gotmpl)?(?:\\.j2)?$/"
+        ]
+      },
+
+      "kubernetes": {
+        "managerFilePatterns": ["/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/"]
+      },
+
+      "kustomize": {
+        "managerFilePatterns": ["/(^|/)kustomization\\.ya?ml(?:\\.j2)?$/"]
       },
 
       "customManagers": [
@@ -105,6 +104,31 @@ data:
           "matchStrings": [
             "kind:\\s*OCIRepository[\\s\\S]*?ref:\\s*\\n[\\s\\S]*?tag:\\s*(?<currentValue>\\S+)[\\s\\S]*?url:\\s*oci://(?<depName>\\S+)",
             "kind:\\s*OCIRepository[\\s\\S]*?url:\\s*oci://(?<depName>\\S+)[\\s\\S]*?ref:\\s*\\n[\\s\\S]*?tag:\\s*(?<currentValue>\\S+)"
+          ],
+          "datasourceTemplate": "docker"
+        },
+        {
+          "customType": "regex",
+          "description": "Process annotated dependencies",
+          "managerFilePatterns": [
+            "/(^|/).+\\.env(?:\\.j2)?$/",
+            "/(^|/).+\\.sh(?:\\.j2)?$/",
+            "/(^|/).+\\.ya?ml(?:\\.j2)?$/"
+          ],
+          "matchStrings": [
+            "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( repository=(?<registryUrl>\\S+))?\\n.+(:\\s|=)(&\\S+\\s)?(?<currentValue>\\S+)",
+            "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n.+/(?<currentValue>(v|\\d)[^/]+)"
+          ],
+          "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}"
+        },
+        {
+          "customType": "regex",
+          "description": "Process inline OCI dependencies",
+          "managerFilePatterns": [
+            "/(^|/).+\\.ya?ml(?:\\.j2)?$/"
+          ],
+          "matchStrings": [
+            "oci://(?<depName>[A-Za-z0-9._/-]+):(?<currentValue>\\S+)"
           ],
           "datasourceTemplate": "docker"
         }
@@ -126,6 +150,7 @@ data:
           "matchManagers": ["flux"],
           "groupName": "Flux controllers",
           "separateMinorPatch": true,
+          "separateMultipleMajor": true,
           "pinDigests": false
         },
         {
@@ -163,7 +188,7 @@ data:
           "enabled": false
         },
         {
-          "matchManagers": ["helm-values", "kustomize"],
+          "matchManagers": ["helm-values", "kustomize", "kubernetes"],
           "matchDatasources": ["docker"],
           "groupName": "GitOps container images",
           "pinDigests": true
@@ -186,42 +211,8 @@ data:
           "automerge": false
         },
         {
-          "matchManagers": ["pre-commit"],
-          "groupName": "pre-commit hooks"
-        },
-        {
-          "matchManagers": ["terraform", "terragrunt"],
-          "groupName": "Terraform",
-          "separateMinorPatch": true
-        },
-        {
-          "matchManagers": ["npm"],
-          "groupName": "npm",
-          "rangeStrategy": "replace"
-        },
-        {
-          "matchManagers": ["pip_requirements", "poetry", "pipenv"],
-          "groupName": "python"
-        },
-        {
-          "matchManagers": ["gomod"],
-          "groupName": "go modules"
-        },
-        {
-          "matchManagers": ["cargo"],
-          "groupName": "rust crates"
-        },
-        {
-          "matchManagers": ["maven", "gradle"],
-          "groupName": "jvm"
-        },
-        {
-          "matchManagers": ["composer"],
-          "groupName": "php composer"
-        },
-        {
-          "matchManagers": ["nuget"],
-          "groupName": "dotnet"
+          "matchManagers": ["mise"],
+          "groupName": "Mise tools"
         },
         {
           "matchManagers": ["dockerfile", "docker-compose"],
@@ -231,8 +222,9 @@ data:
         },
         {
           "matchUpdateTypes": ["major"],
-          "labels": ["major"],
-          "dependencyDashboardApproval": true
+          "addLabels": ["major"],
+          "dependencyDashboardApproval": true,
+          "minimumReleaseAge": "14 days"
         },
         {
           "matchUpdateTypes": ["patch"],

--- a/kubernetes/apps/renovate/renovate-operator/jobs/github-app-token.cronjob.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/github-app-token.cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   name: renovate-github-app-token
   namespace: renovate
 spec:
-  schedule: "*/15 * * * *"
+  schedule: "*/30 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3
@@ -74,7 +74,7 @@ spec:
                   readOnly: true
           containers:
             - name: apply-secret
-              image: docker.io/alpine/k8s:1.34.3
+              image: docker.io/alpine/k8s:1.34.3@sha256:f7dbea27672a55bc2b7dd17cdec2d7a03664a7abef9852cbb8be845d9e70c308
               imagePullPolicy: IfNotPresent
               env:
                 - name: GITHUB_API

--- a/kubernetes/apps/renovate/renovate-operator/jobs/job-cleanup.cronjob.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/job-cleanup.cronjob.yaml
@@ -55,7 +55,7 @@ spec:
             runAsGroup: 65534
           containers:
             - name: cleanup
-              image: docker.io/bitnami/kubectl:latest
+              image: docker.io/alpine/k8s:1.34.3@sha256:f7dbea27672a55bc2b7dd17cdec2d7a03664a7abef9852cbb8be845d9e70c308
               imagePullPolicy: IfNotPresent
               env:
                 - name: HOME

--- a/kubernetes/apps/renovate/renovate-operator/jobs/webgrip-gitops.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/webgrip-gitops.yaml
@@ -27,6 +27,8 @@ spec:
       value: /config/renovate.json
     - name: RENOVATE_BASE_DIR
       value: /tmp
+    - name: HOME
+      value: /tmp
     - name: NODE_OPTIONS
       value: --max-old-space-size=3000
     - name: LOG_LEVEL
@@ -54,8 +56,8 @@ spec:
       memory: 4Gi
   securityContext:
     pod:
-      runAsNonRoot: false
-      runAsUser: 0
-      runAsGroup: 0
+      runAsNonRoot: true
+      runAsUser: 12021
+      runAsGroup: 12021
     container:
       allowPrivilegeEscalation: false

--- a/scripts/lib/oci.sh
+++ b/scripts/lib/oci.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+ACCEPT_HEADER="application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, */*"
+
+fetch_digest() {
+  local image="$1"
+  local tag="$2"
+  local host="${image%%/*}"
+  local path="${image#*/}"
+  local registry_url="https://${host}"
+  local auth_header=()
+
+  case "$host" in
+    ghcr.io)
+      local token
+      token="$(curl -fsSL "https://ghcr.io/token?scope=repository:${path}:pull&service=ghcr.io" | jq -r .token)"
+      auth_header=(-H "Authorization: Bearer ${token}")
+      ;;
+    docker.io|registry-1.docker.io)
+      host="registry-1.docker.io"
+      registry_url="https://${host}"
+      if [[ "$path" != */* ]]; then
+        path="library/${path}"
+      fi
+
+      local token
+      token="$(curl -fsSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${path}:pull" | jq -r .token)"
+      auth_header=(-H "Authorization: Bearer ${token}")
+      ;;
+  esac
+
+  curl -fsSI \
+    "${auth_header[@]}" \
+    -H "Accept: ${ACCEPT_HEADER}" \
+    "${registry_url}/v2/${path}/manifests/${tag}" |
+    awk 'BEGIN { IGNORECASE=1 } /^docker-content-digest:/ { gsub("\r", "", $2); print $2; exit }'
+}

--- a/scripts/update-oci-digests.sh
+++ b/scripts/update-oci-digests.sh
@@ -2,29 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-ACCEPT_HEADER="application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, */*"
-
-fetch_digest() {
-  local image="$1"
-  local tag="$2"
-  local host="${image%%/*}"
-  local path="${image#*/}"
-
-  if [[ "$host" == "ghcr.io" ]]; then
-    local token
-    token="$(curl -fsSL "https://ghcr.io/token?scope=repository:${path}:pull&service=ghcr.io" | jq -r .token)"
-    curl -fsSI \
-      -H "Authorization: Bearer ${token}" \
-      -H "Accept: ${ACCEPT_HEADER}" \
-      "https://${host}/v2/${path}/manifests/${tag}" |
-      awk 'BEGIN { IGNORECASE=1 } /^docker-content-digest:/ { gsub("\r", "", $2); print $2; exit }'
-  else
-    curl -fsSI \
-      -H "Accept: ${ACCEPT_HEADER}" \
-      "https://${host}/v2/${path}/manifests/${tag}" |
-      awk 'BEGIN { IGNORECASE=1 } /^docker-content-digest:/ { gsub("\r", "", $2); print $2; exit }'
-  fi
-}
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/oci.sh"
 
 update_ref_digest() {
   local file="$1"

--- a/scripts/verify-oci-digests.sh
+++ b/scripts/verify-oci-digests.sh
@@ -2,29 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="${1:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-ACCEPT_HEADER="application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, */*"
-
-fetch_digest() {
-  local image="$1"
-  local tag="$2"
-  local host="${image%%/*}"
-  local path="${image#*/}"
-
-  if [[ "$host" == "ghcr.io" ]]; then
-    local token
-    token="$(curl -fsSL "https://ghcr.io/token?scope=repository:${path}:pull&service=ghcr.io" | jq -r .token)"
-    curl -fsSI \
-      -H "Authorization: Bearer ${token}" \
-      -H "Accept: ${ACCEPT_HEADER}" \
-      "https://${host}/v2/${path}/manifests/${tag}" |
-      awk 'BEGIN { IGNORECASE=1 } /^docker-content-digest:/ { gsub("\r", "", $2); print $2; exit }'
-  else
-    curl -fsSI \
-      -H "Accept: ${ACCEPT_HEADER}" \
-      "https://${host}/v2/${path}/manifests/${tag}" |
-      awk 'BEGIN { IGNORECASE=1 } /^docker-content-digest:/ { gsub("\r", "", $2); print $2; exit }'
-  fi
-}
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/oci.sh"
 
 status=0
 


### PR DESCRIPTION
## Summary

- Refactors Renovate config layering so org/runtime behavior lives in the in-cluster ConfigMap and repo-specific policy stays in `.renovaterc.json5`.
- Removes the weekend schedule conflict, enables PR changelog signal, behind-base rebases, Merge Confidence badges, release-age soak windows, and dashboard gates for risky updates.
- Collapses repetitive namespace grouping into templated package rules and trims enabled managers to the GitOps estate.
- Hardens Renovate runtime manifests by running the executor as the image's non-root user, pinning helper images by digest, and reducing GitHub App token refresh churn.
- DRYs OCI digest verification/update logic into `scripts/lib/oci.sh` with Docker Hub and GHCR auth handling.
- Updates Renovate documentation to match the new operating model.

## Validation

- `renovate-config-validator .renovaterc.json5`
- `renovate-config-validator` against the embedded ConfigMap `renovate.json`
- `js-yaml` parse checks for changed Renovate manifests
- `bash -n` for OCI digest scripts and helper
- `./scripts/verify-oci-digests.sh "$PWD"`
- `git diff --check`