### PR TITLE
fix: resolve cluster health audit findings

### DIFF
--- a/kubernetes/apps/cnpg-system/plugin-barman-cloud/app/helmrelease.yaml
+++ b/kubernetes/apps/cnpg-system/plugin-barman-cloud/app/helmrelease.yaml
@@ -22,3 +22,10 @@ spec:
         kind: HelmRepository
         name: cloudnative-pg
         namespace: cnpg-system
+  values:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 256Mi

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -146,6 +146,7 @@ spec:
               matchers:
                 - severity=~"warning|critical"
                 - alertname!="InfoInhibitor"
+              max_alerts: 5
 
         receivers:
           - name: "null"

--- a/kubernetes/apps/renovate/renovate-operator/jobs/job-cleanup.cronjob.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/job-cleanup.cronjob.yaml
@@ -65,8 +65,8 @@ spec:
                 - -ceu
                 - |
                   namespace="renovate"
-                  ttl_days="3"
-                  cutoff_epoch="$(date -u -d "-${ttl_days} days" +%s)"
+                  ttl_secs=$((3 * 86400))
+                  cutoff_epoch=$(( $(date -u +%s) - ttl_secs ))
 
                   kubectl get jobs -n "$namespace" -o go-template='{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}} {{if .status.active}}{{.status.active}}{{else}}0{{end}}{{"\n"}}{{end}}' |
                     while read -r job_name created_ts active; do

--- a/kubernetes/components/cnpg-monitoring/prometheus-rules.yaml
+++ b/kubernetes/components/cnpg-monitoring/prometheus-rules.yaml
@@ -226,11 +226,15 @@ spec:
       rules:
         - alert: CNPGRestoreTestFailed
           expr: |
-            max by (namespace) (
-              kube_job_status_failed{job_name=~"cnpg-restore-test-.*"} == 1
-              and on (namespace, job_name)
-              (time() - kube_job_created{job_name=~"cnpg-restore-test-.*"} < 86400)
-            ) > 0
+            (
+              max by (namespace) (
+                kube_job_status_failed{job_name=~"cnpg-restore-test-.*"} == 1
+                and on (namespace, job_name)
+                (time() - kube_job_created{job_name=~"cnpg-restore-test-.*"} < 86400)
+              ) > 0
+            )
+            unless on (namespace)
+              kube_cronjob_spec_suspend{cronjob="cnpg-restore-test"} == 1
           for: 10m
           labels:
             severity: warning
@@ -259,9 +263,13 @@ spec:
 
         - alert: CNPGRestoreTestStale
           expr: |
-            (kube_cronjob_status_last_successful_time{cronjob="cnpg-restore-test"} == 0)
-            or
-            (time() - kube_cronjob_status_last_successful_time{cronjob="cnpg-restore-test"} > 93600)
+            (
+              (kube_cronjob_status_last_successful_time{cronjob="cnpg-restore-test"} == 0)
+              or
+              (time() - kube_cronjob_status_last_successful_time{cronjob="cnpg-restore-test"} > 93600)
+            )
+            unless on (namespace)
+              kube_cronjob_spec_suspend{cronjob="cnpg-restore-test"} == 1
           for: 30m
           labels:
             severity: warning


### PR DESCRIPTION
## Summary

Four concrete fixes surfaced by the cluster health audit agent run on 2026-05-22.

---

## Changes

### 1. `renovate/job-cleanup` CronJob — daily failure fixed

**Root cause (two bugs):**
- Flux `postBuild.substituteFrom` on `ks-jobs.yaml` silently erased `${ttl_days}` → empty string (not a `cluster-secrets` key)
- BusyBox `date` (alpine/k8s image) does not support GNU `-d "-3 days"` syntax

**Fix:** Replace with pure POSIX epoch arithmetic — no shell `${VAR}` syntax, no GNU date dependency:
```sh
ttl_secs=$((3 * 86400))
cutoff_epoch=$(( $(date -u +%s) - ttl_secs ))
```
The cleanup job will now succeed and prune stale Renovate Jobs older than 3 days.

---

### 2. Alertmanager Discord notifications — unblocked

**Root cause:** `RenovateProjectDependencyIssues` fires for 5 repos simultaneously. Alertmanager groups them into one Discord message. The `{{ range .Alerts }}` template outputs full descriptions for each alert, exceeding Discord's 4096-char limit. Alertmanager had been silently dropping **all** warning/critical notifications for 9+ hours.

**Fix:** Add `max_alerts: 5` to the Discord route. Notifications will be capped at 5 alerts per message; remaining alerts surface on the next interval.

---

### 3. `CNPGRestoreTestStale` / `CNPGRestoreTestFailed` — false-positive alerts silenced

**Root cause:** The restore-test CronJobs are intentionally `suspend: true` while CNPG disaster-recovery clusters are hibernated. The PrometheusRule fired unconditionally, treating suspended CronJobs as "stale".

**Fix:** Add `unless on (namespace) kube_cronjob_spec_suspend{cronjob="cnpg-restore-test"} == 1` to both alert expressions. Alerts only fire when the CronJob is actually running and overdue.

---

### 4. `plugin-barman-cloud` — resource limits added

**Context:** The barman-cloud plugin deployment had 177 restarts over 37 days with no resource limits set. Periodic crashes cause the `cnpg-disaster-recovery` clusters to hit "context deadline exceeded" when CNPG tries to discover the plugin.

**Fix:** Add `requests: 64Mi` / `limits: 256Mi` to prevent unconstrained memory growth.

---

## Testing

- Shell script syntax validated with `bash -n`
- All 4 YAML files validated (no tabs, valid structure)
- Flux reconciliation will apply on next sync

## Not fixed in this PR

- Barman-cloud periodic API-server lease timeouts — monitoring for improvement after resource limits land
- Tempo pod 15,555 restarts — separate investigation needed
- pyroscope-alloy OOMKills — memory tuning needed (separate PR)
- Orphaned `test` Longhorn volume — manual cleanup via Longhorn UI