### PR TITLE
fix(observability): correct Claude Code dashboard queries against live telemetry

### DIFF
--- a/kubernetes/apps/observability/grafana/app/dashboards/claude-code-activity-tools.yaml
+++ b/kubernetes/apps/observability/grafana/app/dashboards/claude-code-activity-tools.yaml
@@ -52,7 +52,7 @@ spec:
         {
           "id": 4, "type": "timeseries", "title": "Active time: user vs CLI", "description": "user = typing/reading; cli = tool execution + response generation.", "gridPos": {"h": 8, "w": 8, "x": 8, "y": 4},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"refId": "A", "expr": "sum by (type) (increase(claude_code_active_time_total_seconds_total[$$__rate_interval])) or sum by (type) (increase(claude_code_active_time_total[$$__rate_interval])) or vector(0)", "legendFormat": "{{type}}"}],
+          "targets": [{"refId": "A", "expr": "sum by (type) (increase(claude_code_active_time_seconds_total[$$__rate_interval])) or vector(0)", "legendFormat": "{{type}}"}],
           "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
           "fieldConfig": {"defaults": {"unit": "s", "custom": {"lineWidth": 2, "fillOpacity": 20, "showPoints": "never", "stacking": {"mode": "normal", "group": "A"}}}, "overrides": []}
         },
@@ -80,7 +80,7 @@ spec:
         {
           "id": 8, "type": "stat", "title": "Avg active min / session", "gridPos": {"h": 4, "w": 4, "x": 20, "y": 8},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"refId": "A", "expr": "((sum(increase(claude_code_active_time_total_seconds_total[$$__range])) or sum(increase(claude_code_active_time_total[$$__range])) or vector(0)) / 60) / clamp_min(sum(increase(claude_code_session_count_total[$$__range])) or vector(0), 1)", "instant": true}],
+          "targets": [{"refId": "A", "expr": "((sum(increase(claude_code_active_time_seconds_total[$$__range])) or vector(0)) / 60) / clamp_min(sum(increase(claude_code_session_count_total[$$__range])) or vector(0), 1)", "instant": true}],
           "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "orientation": "auto", "textMode": "auto", "colorMode": "background", "graphMode": "none"},
           "fieldConfig": {"defaults": {"unit": "m", "decimals": 1, "color": {"mode": "fixed", "fixedColor": "yellow"}}, "overrides": []}
         },
@@ -88,21 +88,21 @@ spec:
         {
           "id": 10, "type": "bargauge", "title": "Tool calls by tool", "gridPos": {"h": 8, "w": 8, "x": 0, "y": 13},
           "datasource": {"type": "loki", "uid": "loki"},
-          "targets": [{"refId": "A", "expr": "topk(15, sum by (tool_name) (count_over_time({service_name=\"claude-code\", event_name=\"tool_result\"} | json [$$__range])))", "queryType": "instant", "legendFormat": "{{tool_name}}"}],
+          "targets": [{"refId": "A", "expr": "topk(15, sum by (tool_name) (count_over_time({service_name=\"claude-code\", event_name=\"tool_result\"} | json tool_name=\"attributes.tool_name\" [$$__range])))", "queryType": "instant", "legendFormat": "{{tool_name}}"}],
           "options": {"orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "displayMode": "gradient", "valueMode": "color"},
           "fieldConfig": {"defaults": {"unit": "short", "decimals": 0, "color": {"mode": "continuous-BlYlRd"}}, "overrides": []}
         },
         {
           "id": 11, "type": "bargauge", "title": "Tool success ratio", "gridPos": {"h": 8, "w": 8, "x": 8, "y": 13},
           "datasource": {"type": "loki", "uid": "loki"},
-          "targets": [{"refId": "A", "expr": "sum by (tool_name) (count_over_time({service_name=\"claude-code\", event_name=\"tool_result\"} | json | success=\"true\" [$$__range])) / clamp_min(sum by (tool_name) (count_over_time({service_name=\"claude-code\", event_name=\"tool_result\"} | json [$$__range])), 1)", "queryType": "instant", "legendFormat": "{{tool_name}}"}],
+          "targets": [{"refId": "A", "expr": "sum by (tool_name) (count_over_time({service_name=\"claude-code\", event_name=\"tool_result\"} | json tool_name=\"attributes.tool_name\", success=\"attributes.success\" | success=\"true\" [$$__range])) / clamp_min(sum by (tool_name) (count_over_time({service_name=\"claude-code\", event_name=\"tool_result\"} | json tool_name=\"attributes.tool_name\" [$$__range])), 1)", "queryType": "instant", "legendFormat": "{{tool_name}}"}],
           "options": {"orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "displayMode": "basic", "valueMode": "color"},
           "fieldConfig": {"defaults": {"unit": "percentunit", "decimals": 2, "min": 0, "max": 1, "thresholds": {"mode": "absolute", "steps": [{"color": "red"}, {"color": "yellow", "value": 0.9}, {"color": "green", "value": 0.98}]}, "color": {"mode": "thresholds"}}, "overrides": []}
         },
         {
           "id": 12, "type": "bargauge", "title": "Tool p90 duration", "gridPos": {"h": 8, "w": 8, "x": 16, "y": 13},
           "datasource": {"type": "loki", "uid": "loki"},
-          "targets": [{"refId": "A", "expr": "topk(15, sort_desc(quantile_over_time(0.9, {service_name=\"claude-code\", event_name=\"tool_result\"} | json | unwrap duration_ms [$$__range]) by (tool_name)))", "queryType": "instant", "legendFormat": "{{tool_name}}"}],
+          "targets": [{"refId": "A", "expr": "topk(15, sort_desc(quantile_over_time(0.9, {service_name=\"claude-code\", event_name=\"tool_result\"} | json tool_name=\"attributes.tool_name\", duration_ms=\"attributes.duration_ms\" | unwrap duration_ms [$$__range]) by (tool_name)))", "queryType": "instant", "legendFormat": "{{tool_name}}"}],
           "options": {"orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "displayMode": "gradient", "valueMode": "color"},
           "fieldConfig": {"defaults": {"unit": "ms", "decimals": 0, "color": {"mode": "continuous-BlYlRd"}}, "overrides": []}
         },
@@ -124,7 +124,7 @@ spec:
         {
           "id": 16, "type": "bargauge", "title": "MCP tool usage", "description": "tool_result events where tool_name matches mcp__<server>__<tool>.", "gridPos": {"h": 8, "w": 8, "x": 16, "y": 22},
           "datasource": {"type": "loki", "uid": "loki"},
-          "targets": [{"refId": "A", "expr": "topk(15, sum by (tool_name) (count_over_time({service_name=\"claude-code\", event_name=\"tool_result\"} | json | tool_name=~\"mcp__.*\" [$$__range])))", "queryType": "instant", "legendFormat": "{{tool_name}}"}],
+          "targets": [{"refId": "A", "expr": "topk(15, sum by (mcp_tool_name) (count_over_time({service_name=\"claude-code\", event_name=\"tool_result\"} | json tool_name=\"attributes.tool_name\" | tool_name=\"mcp_tool\" | json tp=\"attributes.tool_parameters\" | line_format \"{{.tp}}\" | json mcp_tool_name=\"mcp_tool_name\" [$$__range])))", "queryType": "instant", "legendFormat": "{{mcp_tool_name}}"}],
           "options": {"orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "displayMode": "gradient", "valueMode": "color"},
           "fieldConfig": {"defaults": {"unit": "short", "decimals": 0, "color": {"mode": "continuous-GrYlRd"}}, "overrides": []}
         },
@@ -132,7 +132,7 @@ spec:
         {
           "id": 18, "type": "table", "title": "Top bash commands", "description": "Requires OTEL_LOG_TOOL_DETAILS=1.", "gridPos": {"h": 9, "w": 8, "x": 0, "y": 31},
           "datasource": {"type": "loki", "uid": "loki"},
-          "targets": [{"refId": "A", "expr": "topk(20, sum by (full_command) (count_over_time({service_name=\"claude-code\", event_name=\"tool_result\"} | json | full_command!=\"\" [$$__range])))", "queryType": "instant", "legendFormat": "{{full_command}}"}],
+          "targets": [{"refId": "A", "expr": "topk(20, sum by (full_command) (count_over_time({service_name=\"claude-code\", event_name=\"tool_result\"} | json tool_name=\"attributes.tool_name\" | tool_name=\"Bash\" | json tp=\"attributes.tool_parameters\" | line_format \"{{.tp}}\" | json full_command=\"full_command\" | full_command!=\"\" [$$__range])))", "queryType": "instant", "legendFormat": "{{full_command}}"}],
           "transformations": [{"id": "organize", "options": {"excludeByName": {"Time": true}, "renameByName": {"full_command": "Command", "Value": "Count"}}}],
           "options": {"showHeader": true, "sortBy": [{"displayName": "Count", "desc": true}]},
           "fieldConfig": {"defaults": {"custom": {"align": "auto", "filterable": true}}, "overrides": [{"matcher": {"id": "byName", "options": "Count"}, "properties": [{"id": "custom.width", "value": 80}]}]}
@@ -140,7 +140,7 @@ spec:
         {
           "id": 19, "type": "table", "title": "Top files edited", "description": "Requires OTEL_LOG_TOOL_DETAILS=1.", "gridPos": {"h": 9, "w": 8, "x": 8, "y": 31},
           "datasource": {"type": "loki", "uid": "loki"},
-          "targets": [{"refId": "A", "expr": "topk(20, sum by (file_path) (count_over_time({service_name=\"claude-code\", event_name=\"tool_result\"} | json | tool_name=~\"Edit|Write|NotebookEdit\" | file_path!=\"\" [$$__range])))", "queryType": "instant", "legendFormat": "{{file_path}}"}],
+          "targets": [{"refId": "A", "expr": "topk(20, sum by (file_path) (count_over_time({service_name=\"claude-code\", event_name=\"tool_result\"} | json tool_name=\"attributes.tool_name\" | tool_name=~\"Edit|Write|NotebookEdit\" | json ti=\"attributes.tool_input\" | line_format \"{{.ti}}\" | json file_path=\"file_path\" | file_path!=\"\" [$$__range])))", "queryType": "instant", "legendFormat": "{{file_path}}"}],
           "transformations": [{"id": "organize", "options": {"excludeByName": {"Time": true}, "renameByName": {"file_path": "File", "Value": "Edits"}}}],
           "options": {"showHeader": true, "sortBy": [{"displayName": "Edits", "desc": true}]},
           "fieldConfig": {"defaults": {"custom": {"align": "auto", "filterable": true}}, "overrides": [{"matcher": {"id": "byName", "options": "Edits"}, "properties": [{"id": "custom.width", "value": 80}]}]}

--- a/kubernetes/apps/observability/grafana/app/dashboards/claude-code-command-center.yaml
+++ b/kubernetes/apps/observability/grafana/app/dashboards/claude-code-command-center.yaml
@@ -74,7 +74,7 @@ spec:
         {
           "id": 7, "type": "stat", "title": "Active time (24h)", "description": "Active engagement time (user + CLI) in the last 24h.", "gridPos": {"h": 4, "w": 3, "x": 12, "y": 5},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"refId": "A", "expr": "sum(increase(claude_code_active_time_total_seconds_total[24h])) or sum(increase(claude_code_active_time_total[24h])) or vector(0)", "instant": true}],
+          "targets": [{"refId": "A", "expr": "sum(increase(claude_code_active_time_seconds_total[24h])) or vector(0)", "instant": true}],
           "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "orientation": "auto", "textMode": "auto", "colorMode": "background", "graphMode": "none"},
           "fieldConfig": {"defaults": {"unit": "s", "decimals": 0, "color": {"mode": "fixed", "fixedColor": "green"}}, "overrides": []}
         },
@@ -95,7 +95,7 @@ spec:
         {
           "id": 10, "type": "stat", "title": "Request latency p90", "description": "p90 of api_request duration_ms over the range.", "gridPos": {"h": 4, "w": 3, "x": 21, "y": 5},
           "datasource": {"type": "loki", "uid": "loki"},
-          "targets": [{"refId": "A", "expr": "quantile_over_time(0.9, {service_name=\"claude-code\", event_name=\"api_request\"} | json | unwrap duration_ms [$$__range])", "queryType": "instant"}],
+          "targets": [{"refId": "A", "expr": "quantile_over_time(0.9, {service_name=\"claude-code\", event_name=\"api_request\"} | json duration_ms=\"attributes.duration_ms\" | unwrap duration_ms [$$__range])", "queryType": "instant"}],
           "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "orientation": "auto", "textMode": "auto", "colorMode": "background", "graphMode": "none"},
           "fieldConfig": {"defaults": {"unit": "ms", "decimals": 0, "thresholds": {"mode": "absolute", "steps": [{"color": "green"}, {"color": "yellow", "value": 8000}, {"color": "red", "value": 20000}]}}, "overrides": []}
         },
@@ -152,9 +152,9 @@ spec:
           "id": 18, "type": "timeseries", "title": "Request latency p50 / p90 / p99", "gridPos": {"h": 8, "w": 12, "x": 0, "y": 26},
           "datasource": {"type": "loki", "uid": "loki"},
           "targets": [
-            {"refId": "A", "expr": "quantile_over_time(0.5, {service_name=\"claude-code\", event_name=\"api_request\"} | json | unwrap duration_ms [$$__interval])", "queryType": "range", "legendFormat": "p50"},
-            {"refId": "B", "expr": "quantile_over_time(0.9, {service_name=\"claude-code\", event_name=\"api_request\"} | json | unwrap duration_ms [$$__interval])", "queryType": "range", "legendFormat": "p90"},
-            {"refId": "C", "expr": "quantile_over_time(0.99, {service_name=\"claude-code\", event_name=\"api_request\"} | json | unwrap duration_ms [$$__interval])", "queryType": "range", "legendFormat": "p99"}
+            {"refId": "A", "expr": "quantile_over_time(0.5, {service_name=\"claude-code\", event_name=\"api_request\"} | json duration_ms=\"attributes.duration_ms\" | unwrap duration_ms [$$__interval])", "queryType": "range", "legendFormat": "p50"},
+            {"refId": "B", "expr": "quantile_over_time(0.9, {service_name=\"claude-code\", event_name=\"api_request\"} | json duration_ms=\"attributes.duration_ms\" | unwrap duration_ms [$$__interval])", "queryType": "range", "legendFormat": "p90"},
+            {"refId": "C", "expr": "quantile_over_time(0.99, {service_name=\"claude-code\", event_name=\"api_request\"} | json duration_ms=\"attributes.duration_ms\" | unwrap duration_ms [$$__interval])", "queryType": "range", "legendFormat": "p99"}
           ],
           "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
           "fieldConfig": {"defaults": {"unit": "ms", "custom": {"lineWidth": 2, "fillOpacity": 5, "showPoints": "never"}}, "overrides": []}

--- a/kubernetes/apps/observability/grafana/app/dashboards/claude-code-cost-tokens.yaml
+++ b/kubernetes/apps/observability/grafana/app/dashboards/claude-code-cost-tokens.yaml
@@ -119,7 +119,7 @@ spec:
         {
           "id": 16, "type": "stat", "title": "Cost per active hour", "gridPos": {"h": 4, "w": 6, "x": 6, "y": 31},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"refId": "A", "expr": "(sum(increase(claude_code_cost_usage_USD_total{model=~\"$$model\"}[$$__range])) or sum(increase(claude_code_cost_usage_total{model=~\"$$model\"}[$$__range])) or vector(0)) / clamp_min((sum(increase(claude_code_active_time_total_seconds_total[$$__range])) or sum(increase(claude_code_active_time_total[$$__range])) or vector(0)) / 3600, 0.01)", "instant": true}],
+          "targets": [{"refId": "A", "expr": "(sum(increase(claude_code_cost_usage_USD_total{model=~\"$$model\"}[$$__range])) or sum(increase(claude_code_cost_usage_total{model=~\"$$model\"}[$$__range])) or vector(0)) / clamp_min((sum(increase(claude_code_active_time_seconds_total[$$__range])) or vector(0)) / 3600, 0.01)", "instant": true}],
           "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "orientation": "auto", "textMode": "auto", "colorMode": "background", "graphMode": "none"},
           "fieldConfig": {"defaults": {"unit": "currencyUSD", "decimals": 2, "color": {"mode": "fixed", "fixedColor": "yellow"}}, "overrides": []}
         },
@@ -155,9 +155,9 @@ spec:
           "id": 21, "type": "timeseries", "title": "Tokens per request (p50 / p90 / p99)", "description": "From api_request events. Works without content capture.", "gridPos": {"h": 8, "w": 8, "x": 16, "y": 35},
           "datasource": {"type": "loki", "uid": "loki"},
           "targets": [
-            {"refId": "A", "expr": "quantile_over_time(0.5, {service_name=\"claude-code\", event_name=\"api_request\"} | json | unwrap output_tokens [$$__interval])", "queryType": "range", "legendFormat": "output p50"},
-            {"refId": "B", "expr": "quantile_over_time(0.9, {service_name=\"claude-code\", event_name=\"api_request\"} | json | unwrap output_tokens [$$__interval])", "queryType": "range", "legendFormat": "output p90"},
-            {"refId": "C", "expr": "quantile_over_time(0.9, {service_name=\"claude-code\", event_name=\"api_request\"} | json | unwrap input_tokens [$$__interval])", "queryType": "range", "legendFormat": "input p90"}
+            {"refId": "A", "expr": "quantile_over_time(0.5, {service_name=\"claude-code\", event_name=\"api_request\"} | json output_tokens=\"attributes.output_tokens\" | unwrap output_tokens [$$__interval])", "queryType": "range", "legendFormat": "output p50"},
+            {"refId": "B", "expr": "quantile_over_time(0.9, {service_name=\"claude-code\", event_name=\"api_request\"} | json output_tokens=\"attributes.output_tokens\" | unwrap output_tokens [$$__interval])", "queryType": "range", "legendFormat": "output p90"},
+            {"refId": "C", "expr": "quantile_over_time(0.9, {service_name=\"claude-code\", event_name=\"api_request\"} | json input_tokens=\"attributes.input_tokens\" | unwrap input_tokens [$$__interval])", "queryType": "range", "legendFormat": "input p90"}
           ],
           "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
           "fieldConfig": {"defaults": {"unit": "short", "custom": {"lineWidth": 2, "fillOpacity": 5, "showPoints": "never"}}, "overrides": []}

--- a/kubernetes/apps/observability/grafana/app/dashboards/claude-code-events-traces.yaml
+++ b/kubernetes/apps/observability/grafana/app/dashboards/claude-code-events-traces.yaml
@@ -52,7 +52,7 @@ spec:
         {
           "id": 4, "type": "timeseries", "title": "API errors by status & model", "gridPos": {"h": 8, "w": 8, "x": 12, "y": 4},
           "datasource": {"type": "loki", "uid": "loki"},
-          "targets": [{"refId": "A", "expr": "sum by (status_code, model) (count_over_time({service_name=\"claude-code\", event_name=\"api_error\"} | json [$$__interval]))", "queryType": "range", "legendFormat": "{{model}} / {{status_code}}"}],
+          "targets": [{"refId": "A", "expr": "sum by (status_code, model) (count_over_time({service_name=\"claude-code\", event_name=\"api_error\"} | json status_code=\"attributes.status_code\", model=\"attributes.model\" [$$__interval]))", "queryType": "range", "legendFormat": "{{model}} / {{status_code}}"}],
           "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
           "fieldConfig": {"defaults": {"unit": "short", "custom": {"lineWidth": 2, "fillOpacity": 10, "showPoints": "auto", "drawStyle": "bars"}, "color": {"mode": "fixed", "fixedColor": "red"}}, "overrides": []}
         },
@@ -103,7 +103,7 @@ spec:
         {
           "id": 13, "type": "table", "title": "MCP server connections", "description": "Connection outcomes by status & transport over the range.", "gridPos": {"h": 10, "w": 6, "x": 18, "y": 24},
           "datasource": {"type": "loki", "uid": "loki"},
-          "targets": [{"refId": "A", "expr": "sum by (status, transport_type) (count_over_time({service_name=\"claude-code\", event_name=\"mcp_server_connection\"} | json [$$__range]))", "queryType": "instant"}],
+          "targets": [{"refId": "A", "expr": "sum by (status, transport_type) (count_over_time({service_name=\"claude-code\", event_name=\"mcp_server_connection\"} | json status=\"attributes.status\", transport_type=\"attributes.transport_type\" [$$__range]))", "queryType": "instant"}],
           "transformations": [{"id": "organize", "options": {"excludeByName": {"Time": true}, "renameByName": {"status": "Status", "transport_type": "Transport", "Value": "Count"}}}],
           "options": {"showHeader": true, "sortBy": [{"displayName": "Count", "desc": true}]},
           "fieldConfig": {"defaults": {"decimals": 0, "custom": {"align": "auto"}}, "overrides": []}


### PR DESCRIPTION
Follow-up to #350. Now that Claude Code telemetry is actually flowing (`service.name=claude-code`), I verified every query class against live data and fixed two issues the documented schema didn't surface.

## Fixes
- **`active_time` metric name** — it is `claude_code_active_time_seconds_total` (not the guessed `_active_time_total_seconds_total`); dropped the dead fallback. Affects 4 panels across all dashboards. (`cost_usage_USD_total` / `token_usage_tokens_total` / `session_count_total` were already exact.)
- **Loki events nest fields under `attributes.*`** — a bare `| json` explodes every attribute into a stream label, which silently broke `quantile_over_time`/`unwrap` (returned per-line raw values instead of an aggregate). Switched all aggregation queries to explicit extraction, e.g. `| json duration_ms="attributes.duration_ms" | unwrap duration_ms`. Logs panels keep bare `| json` (display only).
- **Nested JSON strings** — MCP tool name, Bash `full_command`, and edited `file_path` live inside `attributes.tool_parameters` / `attributes.tool_input`; extracted via `line_format "{{.x}}" | json field="field"` re-parse.

## Verified live (via Grafana MCP)
- "Top files edited" returns the actual dashboard files with edit counts.
- "Tool success ratio" returns Edit/mcp_tool/Bash all succeeding.
- `quantile_over_time` on `attributes_duration_ms` returns a single clean p90.

## Notes
- `active_time` / `lines_of_code` / `commit` / `pull_request` / `code_edit_tool.decision` populate as those events occur (none yet in the initial SDK session — not a query bug).
- Some MCP server names render as `custom` (Claude Code redacts user-configured MCP server names by default).

Validation: inline dashboard JSON parses, unique panel IDs, `$$`-escaped macros intact; `kustomize build kubernetes/apps/observability/grafana/app` is clean (35 dashboards / 10 folders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)